### PR TITLE
Use identity-first language in access. statement

### DIFF
--- a/accessibility.md
+++ b/accessibility.md
@@ -14,13 +14,13 @@ RustFest is an inclusive conference and as such strives to be accessible to ever
 * Providing clear signage to, from and through the building.
 * Providing quiet spaces for those with sensory issues.
 * Providing accessibility for conference sessions.
-* Providing complimentary tickets for assistants for those with disabilities.
+* Providing complimentary tickets for assistants for disabled participants.
 * Serving a wide range of food and special requests.
 * We are attempting to provide access to non-gendered toilets, but at this time we cannot guarantee this.
 
 If you're not sure whether the concession rate should apply to you, please do get in touch.
 
-Our goal is that the conference and workshops and all other related events are accessible to people with disabilities. However, we are aware that accessibility issues are diverse and we may not have everything covered off in our plans - please reach out, and we will do our very best to confirm we have those requirements under control. Send a mail to [team@rustfest.eu](mailto:team@rustfest.eu)
+Our goal is that the conference and workshops and all other related events are accessible to disabled people. However, we are aware that accessibility issues are diverse and we may not have everything covered off in our plans - please reach out, and we will do our very best to confirm we have those requirements under control. Send a mail to [team@rustfest.eu](mailto:team@rustfest.eu)
 
 We will happily reserve you a ticket if it's not immediately clear whether necessary assistance is provided or you have additional planning to do for your trip to RustFest.
 


### PR DESCRIPTION
There's an ongoing debate about this in the disabled community, but at the time being, most disabled people prefer identity-first language ("disabled person", "disabled software dev", etc.) over person-first language ("person with disabilities", "software dev with disabilities"). So I would recommend to change that.