### PR TITLE
Update sponsors page for Zürich edition

### DIFF
--- a/sponsor-packges.html
+++ b/sponsor-packges.html
@@ -8,8 +8,8 @@ bodytags: with-hero
 
 <div class="hero">
   <section>
-    <h1>RustFest Kyiv 2017</h1>
-    <p>Join the European Rust Community in Kyiv, April 30th</p>
+    <h1>RustFest Zürich 2017</h1>
+    <p>Join the European Rust Community in Zürich, October 1st</p>
   </section>
 
   <section class="packages">


### PR DESCRIPTION
The sponsors page currently still has Kyiv on the header. :)