### PR TITLE
Redirect /origami/ to original origami location

### DIFF
--- a/_layouts/redirect.html
+++ b/_layouts/redirect.html
@@ -1,0 +1,16 @@
+
+
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="canonical" href="{{ page.redirect_to }}"/>
+<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<meta http-equiv="refresh" content="0;url={{ page.redirect_to }}" />
+</head>
+<body>
+    <h1>Redirecting...</h1>
+      <a href="{{ page.redirect_to }}">Click here if you are not redirected.<a>
+      <script>location='{{ page.redirect_to }}'</script>
+</body>
+</html>
+

--- a/origami.html
+++ b/origami.html
@@ -1,0 +1,6 @@
+---
+layout: redirect
+sitemap: false
+permalink: /origami/
+redirect_to:  http://2016.rustfest.eu/origami/
+---


### PR DESCRIPTION
Just makes sure the URL on printed material that I want to hand out on Mozfest works.